### PR TITLE
 Remove Travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Fineract CN Template [![Build Status](https://api.travis-ci.com/apache/fineract-cn-template.svg?branch=develop)](https://travis-ci.com/apache/fineract-cn-template)
+# Apache Fineract CN Template
 
 This project provides a template layout for all Apache Fineract CN services.
 


### PR DESCRIPTION
Due to the removal of the Travis build scripts from the project. The build status in the README.md is now misleading and needs to be removed.